### PR TITLE
Change request parameter name

### DIFF
--- a/src/Folklore/GraphQL/GraphQLController.php
+++ b/src/Folklore/GraphQL/GraphQLController.php
@@ -4,18 +4,18 @@ use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 
 class GraphQLController extends Controller {
-    
+
     public function query(Request $request)
     {
         $query = $request->get('query');
-        $params = $request->get('params');
-        
+        $params = $request->get('variables');
+
         if(is_string($params))
         {
             $params = json_decode($params, true);
         }
-        
+
         return app('graphql')->query($query, $params);
     }
-    
+
 }

--- a/src/Folklore/GraphQL/GraphQLController.php
+++ b/src/Folklore/GraphQL/GraphQLController.php
@@ -8,7 +8,7 @@ class GraphQLController extends Controller {
     public function query(Request $request)
     {
         $query = $request->get('query');
-        $params = $request->get('variables');
+        $params = $request->get(config('graphql.param') ?: 'params');
 
         if(is_string($params))
         {


### PR DESCRIPTION
Relay sends a request using the "variables" parameter name which looks like what [GraphQL PHP](https://github.com/webonyx/graphql-php#http-endpoint) is expecting. Tested this out myself and solved the issue reported in #17.