### PR TITLE
If I did not wrap the parameter key in quotes it

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -436,7 +436,7 @@ GraphQL offer you the possibility to use variables in your query so you don't ne
 When you query the GraphQL endpoint, you can pass a `params` parameter.
 
 ```
-http://homestead.app/graphql?query=query+FetchUserByID($id:String){user(id:$id){id,email}}&params={id:"1"}
+http://homestead.app/graphql?query=query+FetchUserByID($id:String){user(id:$id){id,email}}&params={"id":"1"}
 ```
 
 ### Custom field


### PR DESCRIPTION
would then `json_decode` to null.