### PR TITLE
Seeing if I can use it in 5.1 or 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "type": "project",
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.2.*",
+        "illuminate/support": "5.*",
         "webonyx/graphql-php": "~0.5"
     },
     "require-dev": {


### PR DESCRIPTION
Unless there is a reason it can not be used in 5.1 it would be nice to set the require to 5.* so we can use it in the LTS version of Laravel.

Thanks!