### PR TITLE
Allow disabling of events if not using built in routes?

### DIFF
--- a/src/Folklore/GraphQL/GraphQLServiceProvider.php
+++ b/src/Folklore/GraphQL/GraphQLServiceProvider.php
@@ -11,8 +11,6 @@ class GraphQLServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->bootEvents();
-        
         $this->bootPublishes();
         
         $this->bootTypes();
@@ -20,6 +18,7 @@ class GraphQLServiceProvider extends ServiceProvider
         $this->bootSchemas();
         
         if (config('graphql.routes')) {
+            $this->bootEvents();
             include __DIR__.'/routes.php';
         }
     }


### PR DESCRIPTION
When routes is set to false in the config (so it works with lumen) we don't want to fire the schema event stuff which also uses the route stuff, so we move it down into the same if statement as the routes include