### PR TITLE
Upgraded graphql-php to 0.7.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.5.9",
         "illuminate/support": "~5.1",
-        "webonyx/graphql-php": "0.6.*"
+        "webonyx/graphql-php": "0.7.*"
     },
     "require-dev": {
         "orchestra/testbench": "~3.1"

--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -33,9 +33,16 @@ class GraphQL {
             return $schema;
         }
         
+        $objectTypes = [];
+        $types = array_get($schema, 'types', []);
+
+        foreach($types as $name => $type) {
+            $this->addType($type, $name);
+        }
+
         foreach($this->types as $name => $type)
         {
-            $this->type($name);
+            $objectTypes[] = $this->type($name);
         }
         
         $configQuery = array_get($schema, 'query', []);
@@ -66,8 +73,12 @@ class GraphQL {
                 'name' => 'Mutation'
             ]);
         }
-        
-        return new Schema($queryType, $mutationType);
+
+        return new Schema([
+            'query' => $queryType, 
+            'mutation' => $mutationType,
+            'types' => $objectTypes
+            ]);
     }
     
     protected function buildTypeFromFields($fields, $opts = [])
@@ -174,13 +185,7 @@ class GraphQL {
         
         $instance = $type->toType();
         $this->typesInstances[$name] = $instance;
-        
-        //Check if the object has interfaces
-        if($type->interfaces)
-        {
-            InterfaceType::addImplementationToInterfaces($instance);
-        }
-        
+
         return $instance;
     }
     

--- a/tests/ExampleImplementerType.php
+++ b/tests/ExampleImplementerType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Folklore\GraphQL\Tests;
+
+use GraphQL;
+use GraphQL\Type\Definition\Type;
+use Folklore\GraphQL\Support\Type as GraphQLType;
+
+class ExampleImplementerType extends GraphQLType {
+
+    protected $attributes = [
+        'name' => 'ExampleImplementer',
+        'description' => 'An example of a type that implements an interface'
+    ];
+
+    public function fields()
+    {
+        return [
+            'test' => [
+                'type' => Type::string(),
+                'description' => 'A test field'
+            ]
+        ];
+    }
+
+    public function interfaces()
+    {
+        return [
+            GraphQL::type('ExampleInterface')
+        ];
+    }
+
+}

--- a/tests/ExampleInterfaceType.php
+++ b/tests/ExampleInterfaceType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Folklore\GraphQL\Tests;
+
+use GraphQL\Type\Definition\Type;
+use Folklore\GraphQL\Support\InterfaceType as GraphQLInterfaceType;
+
+class ExampleInterfaceType extends GraphQLInterfaceType {
+
+    protected $attributes = [
+        'name' => 'ExampleInterface',
+        'description' => 'An example interface'
+    ];
+
+    public function fields()
+    {
+        return [
+            'test' => [
+                'type' => Type::string(),
+                'description' => 'A test field'
+            ]
+        ];
+    }
+
+}

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -129,4 +129,25 @@ class GraphQLTest extends TestCase
         $mutation = app($mutations['updateExampleCustom']);
         $this->assertInstanceOf('Folklore\GraphQL\Support\Mutation', $mutation);
     }
+
+    /**
+    * Test interface implementation
+    * 
+    * @test
+    */
+    public function testInterface()
+    {
+        $schema = GraphQL::schema([
+            'types' => [
+                'ExampleInterface' => \Folklore\GraphQL\Tests\ExampleInterfaceType::class,
+                'ExampleImplementer' => \Folklore\GraphQL\Tests\ExampleImplementerType::class
+            ]
+        ]);
+        
+        $interfaceType = $schema->getType('ExampleInterface');
+        $implementerType = $schema->getType('ExampleImplementer');
+
+        $isImplementation = $schema->isPossibleType($interfaceType, $implementerType);
+        $this->assertTrue($isImplementation);
+    }
 }


### PR DESCRIPTION
Support new Schema constructor (takes an object with ‘query’, ‘mutation’ and ‘types’ fields).
Updated the base type construction to incorporate changes to InterfaceType
Added tests for InterfaceType