### PR TITLE
Allow Mutations to be optional

### DIFF
--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -73,7 +73,7 @@ class GraphQL
         
         return new Schema([
             'query' => $query,
-            'mutation' => $mutation,
+            'mutation' => !empty($schemaMutation) ? $mutation : null,
             'types' => $types
         ]);
     }


### PR DESCRIPTION
I have no Mutations in my schema, GraphiQL was throwing an issue as there's an empty Mutation type.

![image](https://cloud.githubusercontent.com/assets/1655361/22955123/5de8d0aa-f312-11e6-923a-1c9fbea14215.png)