### PR TITLE
Added support for enumtypes.

### DIFF
--- a/src/Folklore/GraphQL/Support/Type.php
+++ b/src/Folklore/GraphQL/Support/Type.php
@@ -2,6 +2,7 @@
 
 namespace Folklore\GraphQL\Support;
 
+use GraphQL\Type\Definition\EnumType;
 use Illuminate\Support\Fluent;
 
 use GraphQL\Type\Definition\ObjectType;
@@ -13,6 +14,7 @@ class Type extends Fluent
     protected static $instances = [];
     
     protected $inputObject = false;
+    protected $enumObject = false;
     
     public function attributes()
     {
@@ -103,6 +105,9 @@ class Type extends Fluent
     {
         if ($this->inputObject) {
             return new InputObjectType($this->toArray());
+        }
+        if ($this->enumObject) {
+            return new EnumType($this->toArray());
         }
         return new ObjectType($this->toArray());
     }


### PR DESCRIPTION
This PR adds support for using GraphQL enums.

To create a new EnumType: 

class TestEnumType extends GraphQLType
{
    protected $enumObject = true;

    protected $attributes = [
        'values' => [
            'YES' => [
                'value' => 'YES',
                'description' => 'The answer is YES'
            ],
            'NO' => [
                'value' => 'NO',
                'description' => 'The answer is NO'
            ]
        ],
    ];
}
Add this to your graphql.php type array:

'types' => [TestEnum'=>TestEnumType::class ];

Then use it:

class TestType extends GraphQLType
{
    public function fields()
    {
        return [
            'type' => ['type'=>GraphQL::type('TestEnum')]
        ]
    } 
}