### PR TITLE
Sets 'variables_input_name' to the right value

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -47,7 +47,7 @@ return [
     // Some library use "variables", you can change it here. "params" will stay
     // the default for now but will be changed to "variables" in the next major
     // release.
-    'variables_input_name' => 'params',
+    'variables_input_name' => 'variables',
 
     // Any middleware for the graphql route group
     'middleware' => [],

--- a/tests/EndpointTest.php
+++ b/tests/EndpointTest.php
@@ -52,7 +52,7 @@ class EndpointTest extends TestCase
     {
         $response = $this->call('GET', '/graphql', [
             'query' => $this->queries['examplesWithParams'],
-            'params' => [
+            'variables' => [
                 'index' => 0
             ]
         ]);


### PR DESCRIPTION
graphiql and all clients I have used use 'variables' as the identifier.