### PR TITLE
Add custom schema support on GraphiQL

### DIFF
--- a/src/Folklore/GraphQL/View/GraphiQLComposer.php
+++ b/src/Folklore/GraphQL/View/GraphiQLComposer.php
@@ -1,11 +1,16 @@
 <?php
-
 namespace Folklore\GraphQL\View;
+
+use Illuminate\View\View;
+use Illuminate\Support\Facades\Route;
 
 class GraphiQLComposer
 {
-    public function compose($view)
+    public function compose(View $view)
     {
         $view->graphqlPath = app('router')->has('graphql.query') ? route('graphql.query') : url('/graphql');
+        if ('' !== $schema = (string) Route::current()->parameter('graphql_schema')) {
+            $view->graphqlPath .= '/'. $schema;
+        }
     }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -61,7 +61,7 @@ return [
     // Config for GraphiQL (https://github.com/graphql/graphiql).
     // To disable GraphiQL, set this to null.
     'graphiql' => [
-        'routes' => '/graphiql',
+        'routes' => '/graphiql/{graphql_schema?}',
         'middleware' => [],
         'view' => 'graphql::graphiql'
     ],


### PR DESCRIPTION
Current GraphiQL controller doesn't seem to support specifying the custom schema using `{graphql_schema?}` route parameter.

This PR adds an ability to specify the schema using the URL parameter by appending the same parameter to the query URL.

If you have better idea to improve this solution, please suggest :)

Ref: https://github.com/Folkloreatelier/laravel-graphql/issues/115#issuecomment-302999148