### PR TITLE
fix: change `params` to `variables`

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -18,10 +18,10 @@ query FetchUserByID($id: String) {
 }
 ```
 
-When you query the GraphQL endpoint, you can pass a `params` parameter.
+When you query the GraphQL endpoint, you can pass a `variables` parameter.
 
 ```
-http://homestead.app/graphql?query=query+FetchUserByID($id:String){user(id:$id){id,email}}&params={"id":"1"}
+http://homestead.app/graphql?query=query+FetchUserByID($id:String){user(id:$id){id,email}}&variables={"id":"1"}
 ```
 
 ### Query nested resource

--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -128,9 +128,9 @@ class GraphQL
         return $objectType;
     }
     
-    public function query($query, $params = [], $opts = [])
+    public function query($query, $variables = [], $opts = [])
     {
-        $result = $this->queryAndReturnResult($query, $params, $opts);
+        $result = $this->queryAndReturnResult($query, $variables, $opts);
         
         if (!empty($result->errors)) {
             $errorFormatter = config('graphql.error_formatter', [self::class, 'formatError']);
@@ -146,7 +146,7 @@ class GraphQL
         }
     }
     
-    public function queryAndReturnResult($query, $params = [], $opts = [])
+    public function queryAndReturnResult($query, $variables = [], $opts = [])
     {
         $root = array_get($opts, 'root', null);
         $context = array_get($opts, 'context', null);
@@ -155,7 +155,7 @@ class GraphQL
         
         $schema = $this->schema($schemaName);
         
-        $result = GraphQLBase::executeAndReturnResult($schema, $query, $root, $context, $params, $operationName);
+        $result = GraphQLBase::executeAndReturnResult($schema, $query, $root, $context, $variables, $operationName);
         
         return $result;
     }


### PR DESCRIPTION
According to `config/graphql.php`: 

```
    // The name of the input that contain variables when you query the endpoint.
    // Most library use "variables", you can change it here in case you need it.
    // In previous versions, the default used to be "params"
```

`params` should be `variables`