### PR TITLE
Fixes GraphiQLComposer for use within Lumen

### DIFF
--- a/src/Folklore/GraphQL/View/GraphiQLComposer.php
+++ b/src/Folklore/GraphQL/View/GraphiQLComposer.php
@@ -1,6 +1,7 @@
 <?php
 namespace Folklore\GraphQL\View;
 
+use InvalidArgumentException;
 use Illuminate\View\View;
 use Illuminate\Support\Facades\Route;
 
@@ -8,10 +9,16 @@ class GraphiQLComposer
 {
     public function compose(View $view)
     {
-        $hasRoute = app()->bound('router') && app('router')->has('graphql.query');
+        try {
+            $hasRoute = route('graphql.query');
+        } catch (InvalidArgumentException $e) {
+            $hasRoute = false;
+        }
+
         $schema = $view->schema;
-        if (isset($schema) && !empty($schema)) {
-            $view->graphqlPath = $hasRoute ? route('graphql.query', [$schema]) : url('/graphql/'.$schema);
+
+        if (! empty($schema)) {
+            $view->graphqlPath = $hasRoute ? route('graphql.query', [$schema]) : url('/graphql/' . $schema);
         } else {
             $view->graphqlPath = $hasRoute ? route('graphql.query') : url('/graphql');
         }


### PR DESCRIPTION
Due to Lumen not having `router` bound to the container, the view
composer for the GraphiQL tool was not properly setting the graphqlPath.