### PR TITLE
Small code fix in Field.php

### DIFF
--- a/src/Folklore/GraphQL/Support/Field.php
+++ b/src/Folklore/GraphQL/Support/Field.php
@@ -45,7 +45,7 @@ class Field extends Fluent
         $attributes = $this->attributes();
         $args = $this->args();
         
-        $attributes = array_merge($this->attributes, [
+        $attributes = array_merge([
             'args' => $args
         ], $attributes);
         


### PR DESCRIPTION
There was an unused assignment of a variable ($attributes), which was overwritten three lines later. This change keeps the clear syntax with the assignment of local variables but avoids duplication of pulling in `$this->attributes()`.