### PR TITLE
Optimize service provider

### DIFF
--- a/src/Folklore/GraphQL/ServiceProvider.php
+++ b/src/Folklore/GraphQL/ServiceProvider.php
@@ -2,67 +2,179 @@
 
 use GraphQL\Validator\DocumentValidator;
 use GraphQL\Validator\Rules\DisableIntrospection;
+use GraphQL\Validator\Rules\QueryComplexity;
+use GraphQL\Validator\Rules\QueryDepth;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\Routing\Registrar as Router;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
+use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
 {
-    /**
-     * Get the active router.
-     *
-     * @return Router
-     */
-    protected function getRouter()
-    {
-        return $this->app['router'];
-    }
-
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $this->bootEvents();
-
-        $this->bootPublishes();
-
-        $this->bootTypes();
-
-        $this->bootSchemas();
-
-        $this->bootRouter();
-
-        $this->bootViews();
-        
-        $this->bootSecurity();
-    }
+	/**
+	 * Register any application services.
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+		$this->registerGraphQL();
+		
+		$this->registerConsole();
+	}
+	
+	/**
+	 * Bootstrap any application services.
+	 *
+	 * @return void
+	 */
+	public function boot(Config $config, Router $router, ViewFactory $viewFactory)
+	{
+		$this->bootPublishes();
+		
+		$this->bootRouter($config, $router);
+		
+		$this->bootViews($config, $viewFactory);
+	}
+	
+	/**
+	 * Get the services provided by the provider.
+	 *
+	 * @return array
+	 */
+	public function provides()
+	{
+		return ['graphql'];
+	}
+	
+	/**
+	 * Register GraphQL facade
+	 *
+	 * @return void
+	 */
+	protected function registerGraphQL()
+	{
+		$this->app->singleton('graphql', function ($app) {
+			
+			$graphql = new GraphQL($app);
+			$config = $app->make('config');
+			
+			$this->addTypes($config, $graphql);
+			
+			$this->addSchemas($config, $graphql);
+			
+			$this->registerEventListeners(
+				$app->make('events'),
+				$app->make('router'),
+				$graphql
+			);
+			
+			$this->applySecurityRules();
+			
+			return $graphql;
+		});
+	}
+	
+	/**
+	 * Add types from config
+	 *
+	 * @param Config $config
+	 * @param GraphQL $graphql
+	 * @return void
+	 */
+	protected function addTypes(Config $config, GraphQL $graphql)
+	{
+		$types = $config->get('graphql.types', []);
+		
+		foreach ($types as $name => $type) {
+			$graphql->addType($type, is_numeric($name) ? null : $name);
+		}
+	}
+	
+	/**
+	 * Add schemas from config
+	 *
+	 * @param Config $config
+	 * @param GraphQL $graphql
+	 * @return void
+	 */
+	protected function addSchemas(Config $config, GraphQL $graphql)
+	{
+		$schemas = $config->get('graphql.schemas', []);
+		
+		foreach ($schemas as $name => $schema) {
+			$graphql->addSchema($name, $schema);
+		}
+	}
+	
+	/**
+	 * Bootstrap events
+	 *
+	 * @param EventDispatcher $events
+	 * @param Router $router
+	 * @param GraphQL $graphql
+	 * @return void
+	 */
+	protected function registerEventListeners(EventDispatcher $events, Router $router, GraphQL $graphql)
+	{
+		// Update the schema route pattern when schema is added
+		$events->listen(Events\SchemaAdded::class, function () use ($router, $graphql) {
+			$schemaNames = array_keys($graphql->getSchemas());
+			$router->pattern('graphql_schema', '('.implode('|', $schemaNames).')');
+		});
+	}
+	
+	/**
+	 * Configure security from config
+	 * @return void
+	 */
+	protected function applySecurityRules()
+	{
+		$maxQueryComplexity = config('graphql.security.query_max_complexity');
+		if ($maxQueryComplexity !== null) {
+			/** @var QueryComplexity $queryComplexity */
+			$queryComplexity = DocumentValidator::getRule('QueryComplexity');
+			$queryComplexity->setMaxQueryComplexity($maxQueryComplexity);
+		}
+		
+		$maxQueryDepth = config('graphql.security.query_max_depth');
+		if ($maxQueryDepth !== null) {
+			/** @var QueryDepth $queryDepth */
+			$queryDepth = DocumentValidator::getRule('QueryDepth');
+			$queryDepth->setMaxQueryDepth($maxQueryDepth);
+		}
+		
+		$disableIntrospection = config('graphql.security.disable_introspection');
+		if ($disableIntrospection === true) {
+			/** @var DisableIntrospection $disableIntrospection */
+			$disableIntrospection = DocumentValidator::getRule('DisableIntrospection');
+			$disableIntrospection->setEnabled(DisableIntrospection::ENABLED);
+		}
+	}
+	
+	/**
+	 * Register console commands
+	 *
+	 * @return void
+	 */
+	protected function registerConsole()
+	{
+		$this->commands(Console\TypeMakeCommand::class);
+		$this->commands(Console\QueryMakeCommand::class);
+		$this->commands(Console\MutationMakeCommand::class);
+	}
 
     /**
      * Bootstrap router
      *
      * @return void
      */
-    protected function bootRouter()
+    protected function bootRouter(Config $config, Router $router)
     {
-        if (config('graphql.routes')) {
-            $router = $this->getRouter();
+        if ($config->get('graphql.routes')) {
             include __DIR__.'/routes.php';
         }
-    }
-
-    /**
-     * Bootstrap events
-     *
-     * @return void
-     */
-    protected function bootEvents()
-    {
-        //Update the schema route pattern when schema is added
-        $this->app['events']->listen(\Folklore\GraphQL\Events\SchemaAdded::class, function () {
-            $schemaNames = array_keys($this->app['graphql']->getSchemas());
-            $this->getRouter()->pattern('graphql_schema', '('.implode('|', $schemaNames).')');
-        });
     }
 
     /**
@@ -87,121 +199,19 @@ class ServiceProvider extends BaseServiceProvider
             $viewsPath => base_path('resources/views/vendor/graphql'),
         ], 'views');
     }
-
-    /**
-     * Add types from config
-     *
-     * @return void
-     */
-    protected function bootTypes()
+	
+	/**
+	 * Bootstrap Views
+	 *
+	 * @param Config $config
+	 * @param ViewFactory $viewFactory
+	 * @return void
+	 */
+    protected function bootViews(Config $config, ViewFactory $viewFactory)
     {
-        $configTypes = config('graphql.types');
-        foreach ($configTypes as $name => $type) {
-            if (is_numeric($name)) {
-                $this->app['graphql']->addType($type);
-            } else {
-                $this->app['graphql']->addType($type, $name);
-            }
+        if ($config->get('graphql.graphiql', true)) {
+            $view = $config->get('graphql.graphiql.view', 'graphql::graphiql');
+            $viewFactory->composer($view, View\GraphiQLComposer::class);
         }
-    }
-
-    /**
-     * Add schemas from config
-     *
-     * @return void
-     */
-    protected function bootSchemas()
-    {
-        $configSchemas = config('graphql.schemas');
-        foreach ($configSchemas as $name => $schema) {
-            $this->app['graphql']->addSchema($name, $schema);
-        }
-    }
-
-    /**
-     * Bootstrap Views
-     *
-     * @return void
-     */
-    protected function bootViews()
-    {
-        $graphiQL = config('graphql.graphiql', true);
-        if ($graphiQL) {
-            $view = config('graphql.graphiql.view', 'graphql::graphiql');
-            app('view')->composer($view, \Folklore\GraphQL\View\GraphiQLComposer::class);
-        }
-    }
-    
-    /**
-     * Configure security from config
-     * @return void
-     */
-    protected function bootSecurity()
-    {
-        $maxQueryComplexity = config('graphql.security.query_max_complexity');
-        if ($maxQueryComplexity !== null) {
-            $queryComplexity = DocumentValidator::getRule('QueryComplexity');
-            $queryComplexity->setMaxQueryComplexity($maxQueryComplexity);
-        }
-
-        $maxQueryDepth = config('graphql.security.query_max_depth');
-        if ($maxQueryDepth !== null) {
-            $queryDepth = DocumentValidator::getRule('QueryDepth');
-            $queryDepth->setMaxQueryDepth($maxQueryDepth);
-        }
-
-        $disableIntrospection = config('graphql.security.disable_introspection');
-        if ($disableIntrospection === true) {
-            $disableIntrospection = DocumentValidator::getRule('DisableIntrospection');
-            /** @var \GraphQL\Validator\Rules\DisableIntrospection $disableIntrospection */
-            $disableIntrospection->setEnabled(DisableIntrospection::ENABLED);
-        }
-    }
-
-    /**
-     * Register any application services.
-     *
-     * @return void
-     */
-    public function register()
-    {
-        $this->registerGraphQL();
-
-        $this->registerConsole();
-    }
-
-    /**
-     * Register GraphQL facade
-     *
-     * @return void
-     */
-    public function registerGraphQL()
-    {
-        $this->app->singleton('graphql', function ($app) {
-            return new GraphQL($app);
-        });
-    }
-
-    /**
-     * Register console commands
-     *
-     * @return void
-     */
-    public function registerConsole()
-    {
-        $this->commands(\Folklore\GraphQL\Console\TypeMakeCommand::class);
-        $this->commands(\Folklore\GraphQL\Console\QueryMakeCommand::class);
-        $this->commands(\Folklore\GraphQL\Console\MutationMakeCommand::class);
-    }
-
-
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return ['graphql'];
     }
 }

--- a/src/Folklore/GraphQL/ServiceProvider.php
+++ b/src/Folklore/GraphQL/ServiceProvider.php
@@ -44,13 +44,10 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerEventListeners(GraphQL $graphql)
     {
         // Update the schema route pattern when schema is added
-        $this->app['events']->listen(
-            Events\SchemaAdded::class,
-            function() use ($graphql) {
-                $schemaNames = array_keys($graphql->getSchemas());
-                $this->app['router']->pattern('graphql_schema', '('.implode('|', $schemaNames).')');
-            }
-        );
+        $this->app['events']->listen(Events\SchemaAdded::class, function() use ($graphql) {
+            $schemaNames = array_keys($graphql->getSchemas());
+            $this->app['router']->pattern('graphql_schema', '('.implode('|', $schemaNames).')');
+        });
     }
 
     /**

--- a/src/Folklore/GraphQL/ServiceProvider.php
+++ b/src/Folklore/GraphQL/ServiceProvider.php
@@ -5,165 +5,185 @@ use GraphQL\Validator\Rules\DisableIntrospection;
 use GraphQL\Validator\Rules\QueryComplexity;
 use GraphQL\Validator\Rules\QueryDepth;
 use Illuminate\Contracts\Config\Repository as Config;
-use Illuminate\Contracts\Routing\Registrar as Router;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
+use Illuminate\Contracts\Routing\Registrar as Router;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
 {
-	/**
-	 * Register any application services.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
-		$this->registerGraphQL();
-		
-		$this->registerConsole();
-	}
-	
-	/**
-	 * Bootstrap any application services.
-	 *
-	 * @return void
-	 */
-	public function boot(Config $config, Router $router, ViewFactory $viewFactory)
-	{
-		$this->bootPublishes();
-		
-		$this->bootRouter($config, $router);
-		
-		$this->bootViews($config, $viewFactory);
-	}
-	
-	/**
-	 * Get the services provided by the provider.
-	 *
-	 * @return array
-	 */
-	public function provides()
-	{
-		return ['graphql'];
-	}
-	
-	/**
-	 * Register GraphQL facade
-	 *
-	 * @return void
-	 */
-	protected function registerGraphQL()
-	{
-		$this->app->singleton('graphql', function ($app) {
-			
-			$graphql = new GraphQL($app);
-			$config = $app->make('config');
-			
-			$this->addTypes($config, $graphql);
-			
-			$this->addSchemas($config, $graphql);
-			
-			$this->registerEventListeners(
-				$app->make('events'),
-				$app->make('router'),
-				$graphql
-			);
-			
-			$this->applySecurityRules();
-			
-			return $graphql;
-		});
-	}
-	
-	/**
-	 * Add types from config
-	 *
-	 * @param Config $config
-	 * @param GraphQL $graphql
-	 * @return void
-	 */
-	protected function addTypes(Config $config, GraphQL $graphql)
-	{
-		$types = $config->get('graphql.types', []);
-		
-		foreach ($types as $name => $type) {
-			$graphql->addType($type, is_numeric($name) ? null : $name);
-		}
-	}
-	
-	/**
-	 * Add schemas from config
-	 *
-	 * @param Config $config
-	 * @param GraphQL $graphql
-	 * @return void
-	 */
-	protected function addSchemas(Config $config, GraphQL $graphql)
-	{
-		$schemas = $config->get('graphql.schemas', []);
-		
-		foreach ($schemas as $name => $schema) {
-			$graphql->addSchema($name, $schema);
-		}
-	}
-	
-	/**
-	 * Bootstrap events
-	 *
-	 * @param EventDispatcher $events
-	 * @param Router $router
-	 * @param GraphQL $graphql
-	 * @return void
-	 */
-	protected function registerEventListeners(EventDispatcher $events, Router $router, GraphQL $graphql)
-	{
-		// Update the schema route pattern when schema is added
-		$events->listen(Events\SchemaAdded::class, function () use ($router, $graphql) {
-			$schemaNames = array_keys($graphql->getSchemas());
-			$router->pattern('graphql_schema', '('.implode('|', $schemaNames).')');
-		});
-	}
-	
-	/**
-	 * Configure security from config
-	 * @return void
-	 */
-	protected function applySecurityRules()
-	{
-		$maxQueryComplexity = config('graphql.security.query_max_complexity');
-		if ($maxQueryComplexity !== null) {
-			/** @var QueryComplexity $queryComplexity */
-			$queryComplexity = DocumentValidator::getRule('QueryComplexity');
-			$queryComplexity->setMaxQueryComplexity($maxQueryComplexity);
-		}
-		
-		$maxQueryDepth = config('graphql.security.query_max_depth');
-		if ($maxQueryDepth !== null) {
-			/** @var QueryDepth $queryDepth */
-			$queryDepth = DocumentValidator::getRule('QueryDepth');
-			$queryDepth->setMaxQueryDepth($maxQueryDepth);
-		}
-		
-		$disableIntrospection = config('graphql.security.disable_introspection');
-		if ($disableIntrospection === true) {
-			/** @var DisableIntrospection $disableIntrospection */
-			$disableIntrospection = DocumentValidator::getRule('DisableIntrospection');
-			$disableIntrospection->setEnabled(DisableIntrospection::ENABLED);
-		}
-	}
-	
-	/**
-	 * Register console commands
-	 *
-	 * @return void
-	 */
-	protected function registerConsole()
-	{
-		$this->commands(Console\TypeMakeCommand::class);
-		$this->commands(Console\QueryMakeCommand::class);
-		$this->commands(Console\MutationMakeCommand::class);
-	}
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->registerGraphQL();
+
+        $this->registerConsole();
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot(Config $config, Router $router, ViewFactory $viewFactory)
+    {
+        $this->bootPublishes();
+
+        $this->bootRouter($config, $router);
+
+        $this->bootViews($config, $viewFactory);
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['graphql'];
+    }
+
+    /**
+     * Register GraphQL facade
+     *
+     * @return void
+     */
+    protected function registerGraphQL()
+    {
+        $this->app->singleton('graphql', function ($app) {
+
+            $graphql = new GraphQL($app);
+            $config = $app->make('config');
+
+            $this->addTypes($config, $graphql);
+
+            $this->addSchemas($config, $graphql);
+
+            $this->registerEventListeners($app->make('events'), $app->make('router'), $graphql);
+
+            $this->applySecurityRules();
+
+            return $graphql;
+        });
+    }
+
+    /**
+     * Add types from config
+     *
+     * @param Config $config
+     * @param GraphQL $graphql
+     * @return void
+     */
+    protected function addTypes(Config $config, GraphQL $graphql)
+    {
+        $types = $config->get('graphql.types', []);
+
+        foreach ($types as $name => $type) {
+            $graphql->addType($type, is_numeric($name) ? null : $name);
+        }
+    }
+
+    /**
+     * Add schemas from config
+     *
+     * @param Config $config
+     * @param GraphQL $graphql
+     * @return void
+     */
+    protected function addSchemas(Config $config, GraphQL $graphql)
+    {
+        $schemas = $config->get('graphql.schemas', []);
+
+        foreach ($schemas as $name => $schema) {
+            $graphql->addSchema($name, $schema);
+        }
+    }
+
+    /**
+     * Bootstrap events
+     *
+     * @param EventDispatcher $events
+     * @param Router $router
+     * @param GraphQL $graphql
+     * @return void
+     */
+    protected function registerEventListeners(EventDispatcher $events, Router $router, GraphQL $graphql)
+    {
+        // Update the schema route pattern when schema is added
+        $events->listen(Events\SchemaAdded::class, function () use ($router, $graphql) {
+            $schemaNames = array_keys($graphql->getSchemas());
+            $router->pattern('graphql_schema', '('.implode('|', $schemaNames).')');
+        });
+    }
+
+    /**
+     * Configure security from config
+     *
+     * @return void
+     */
+    protected function applySecurityRules()
+    {
+        $maxQueryComplexity = config('graphql.security.query_max_complexity');
+        if ($maxQueryComplexity !== null) {
+            /** @var QueryComplexity $queryComplexity */
+            $queryComplexity = DocumentValidator::getRule('QueryComplexity');
+            $queryComplexity->setMaxQueryComplexity($maxQueryComplexity);
+        }
+
+        $maxQueryDepth = config('graphql.security.query_max_depth');
+        if ($maxQueryDepth !== null) {
+            /** @var QueryDepth $queryDepth */
+            $queryDepth = DocumentValidator::getRule('QueryDepth');
+            $queryDepth->setMaxQueryDepth($maxQueryDepth);
+        }
+
+        $disableIntrospection = config('graphql.security.disable_introspection');
+        if ($disableIntrospection === true) {
+            /** @var DisableIntrospection $disableIntrospection */
+            $disableIntrospection = DocumentValidator::getRule('DisableIntrospection');
+            $disableIntrospection->setEnabled(DisableIntrospection::ENABLED);
+        }
+    }
+
+    /**
+     * Register console commands
+     *
+     * @return void
+     */
+    protected function registerConsole()
+    {
+        $this->commands(Console\TypeMakeCommand::class);
+        $this->commands(Console\QueryMakeCommand::class);
+        $this->commands(Console\MutationMakeCommand::class);
+    }
+
+    /**
+     * Bootstrap publishes
+     *
+     * @return void
+     */
+    protected function bootPublishes()
+    {
+        $configPath = __DIR__.'/../../config';
+        $viewsPath = __DIR__.'/../../resources/views';
+
+        $this->mergeConfigFrom($configPath.'/config.php', 'graphql');
+
+        $this->loadViewsFrom($viewsPath, 'graphql');
+
+        $this->publishes([
+            $configPath.'/config.php' => config_path('graphql.php'),
+        ], 'config');
+
+        $this->publishes([
+            $viewsPath => base_path('resources/views/vendor/graphql'),
+        ], 'views');
+    }
 
     /**
      * Bootstrap router
@@ -178,35 +198,12 @@ class ServiceProvider extends BaseServiceProvider
     }
 
     /**
-     * Bootstrap publishes
+     * Bootstrap Views
      *
+     * @param Config $config
+     * @param ViewFactory $viewFactory
      * @return void
      */
-    protected function bootPublishes()
-    {
-        $configPath = __DIR__.'/../../config';
-        $viewsPath = __DIR__.'/../../resources/views';
-
-        $this->mergeConfigFrom($configPath.'/config.php', 'graphql');
-        
-        $this->loadViewsFrom($viewsPath, 'graphql');
-
-        $this->publishes([
-            $configPath.'/config.php' => config_path('graphql.php'),
-        ], 'config');
-
-        $this->publishes([
-            $viewsPath => base_path('resources/views/vendor/graphql'),
-        ], 'views');
-    }
-	
-	/**
-	 * Bootstrap Views
-	 *
-	 * @param Config $config
-	 * @param ViewFactory $viewFactory
-	 * @return void
-	 */
     protected function bootViews(Config $config, ViewFactory $viewFactory)
     {
         if ($config->get('graphql.graphiql', true)) {

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -217,7 +217,7 @@ class GraphQLTest extends TestCase
     {
         $this->expectsEvents(TypeAdded::class);
 	
-	    $this->app['events']->shouldReceive('listen')->with(SchemaAdded::class, Closure::class)->once();
+	    $this->app['events']->shouldReceive('listen');
         
         GraphQL::addType(CustomExampleType::class);
 

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -216,6 +216,8 @@ class GraphQLTest extends TestCase
     public function testAddType()
     {
         $this->expectsEvents(TypeAdded::class);
+	
+	    $this->app['events']->shouldReceive('listen')->with(SchemaAdded::class, Closure::class)->once();
         
         GraphQL::addType(CustomExampleType::class);
 
@@ -270,6 +272,8 @@ class GraphQLTest extends TestCase
     public function testAddSchema()
     {
         $this->expectsEvents(SchemaAdded::class);
+	
+	    $this->app['events']->shouldReceive('listen')->with(SchemaAdded::class, Closure::class)->once();
         
         GraphQL::addSchema('custom_add', [
             'query' => [


### PR DESCRIPTION
Hi there,

I originally reorganized the service provider while I was optimizing it, but reverted those changes because the diff is too hard to look through. If you like the PR, I would love to reorganize things after it's been approved (sort methods by visibility and dependency).

This PR implements:

- Wait to register types, schemas, event listeners, and security rules until GraphQL is resolved from the container — this means that significantly less `boot()` logic needs to run for requests that don't use GraphQL at all
- Replace helper methods like `config()` with `$this->app['config']`
- Simplify references to classes in the `Folklore\GraphQL` namespace