### PR TITLE
Fix LumenServiceProvider::getRouter()

### DIFF
--- a/src/Folklore/GraphQL/LumenServiceProvider.php
+++ b/src/Folklore/GraphQL/LumenServiceProvider.php
@@ -11,7 +11,7 @@ class LumenServiceProvider extends ServiceProvider
      */
     protected function getRouter()
     {
-        return $this->app;
+        return $this->app->router;
     }
 
     /**


### PR DESCRIPTION
Otherwise calling `php artisan` dies with:

```
[Symfony\Component\Debug\Exception\FatalThrowableError]
Call to undefined method Laravel\Lumen\Application::group()
```

Versions:

- PHP 7.1.9
- Lumen 5.5.0
- folklore/graphql 1.0.25