### PR TITLE
Updated Field to include $args in the authorize method

### DIFF
--- a/src/Folklore/GraphQL/Support/Field.php
+++ b/src/Folklore/GraphQL/Support/Field.php
@@ -12,7 +12,7 @@ class Field extends Fluent
      * Override this in your queries or mutations
      * to provide custom authorization
      */
-    public function authorize()
+    public function authorize($args)
     {
         return true;
     }
@@ -45,7 +45,7 @@ class Field extends Fluent
             $args = func_get_args();
 
             // Authorize
-            if (call_user_func($authorize) !== true) {
+            if (call_user_func_array($authorize, $args) !== true) {
                 throw new AuthorizationError('Unauthorized');
             }
 

--- a/tests/Objects/ExamplesAuthorizeQuery.php
+++ b/tests/Objects/ExamplesAuthorizeQuery.php
@@ -9,7 +9,7 @@ class ExamplesAuthorizeQuery extends ExamplesQuery
         'name' => 'Examples authorize query'
     ];
 
-    public function authorize()
+    public function authorize($args)
     {
         return false;
     }


### PR DESCRIPTION
During my usage of `authorize()` I often noticed that I needed the `$args`.

Example: Users can edit their own profile, but not that of others. In an `updateProfile` mutatation, I want to check if the supplied `id` argument matches the ID of the user who initiated the mutation. The `authorize` method is where stuff like this is supposed to happen, so I need `$args` there.