### PR TITLE
Add missing argument to authorize method

### DIFF
--- a/src/Folklore/GraphQL/Support/Field.php
+++ b/src/Folklore/GraphQL/Support/Field.php
@@ -12,7 +12,7 @@ class Field extends Fluent
      * Override this in your queries or mutations
      * to provide custom authorization
      */
-    public function authorize($args)
+    public function authorize($root, $args)
     {
         return true;
     }

--- a/tests/Objects/ExamplesAuthorizeQuery.php
+++ b/tests/Objects/ExamplesAuthorizeQuery.php
@@ -9,7 +9,7 @@ class ExamplesAuthorizeQuery extends ExamplesQuery
         'name' => 'Examples authorize query'
     ];
 
-    public function authorize($args)
+    public function authorize($root, $args)
     {
         return false;
     }


### PR DESCRIPTION
Fixes a missing argument for the authorize method. Introduced in #199.

This is a BC to the api so you might want to release as a minor update perhaps. Your call.