### PR TITLE
Added per schema middleware

### DIFF
--- a/src/Folklore/GraphQL/GraphQLController.php
+++ b/src/Folklore/GraphQL/GraphQLController.php
@@ -5,6 +5,18 @@ use Illuminate\Http\Response;
 
 class GraphQLController extends Controller
 {
+    public function __construct(Request $request)
+    {
+        $schema = $request->route('graphql_schema') ?
+          $request->route('graphql_schema') : config('graphql.schema');
+
+        $middleware = config('graphql.middleware_schema.' . $schema, null);
+
+        if ($middleware) {
+            $this->middleware($middleware);
+        }
+    }
+
     public function query(Request $request, $schema = null)
     {
         $isBatch = !$request->has('query');

--- a/src/Folklore/GraphQL/GraphQLController.php
+++ b/src/Folklore/GraphQL/GraphQLController.php
@@ -8,7 +8,7 @@ class GraphQLController extends Controller
     public function __construct(Request $request)
     {
         $schema = $request->route('graphql_schema') ?
-          $request->route('graphql_schema') : config('graphql.schema');
+            $request->route('graphql_schema') : config('graphql.schema');
 
         $middleware = config('graphql.middleware_schema.' . $schema, null);
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -55,6 +55,13 @@ return [
      */
     'middleware' => [],
 
+    /**
+     * Any middleware for a specific 'graphql' schema
+     */
+    'middleware_schema' => [
+        'default' => [],
+    ],
+
     /*
      * Any headers that will be added to the response returned by the default controller
      */


### PR DESCRIPTION
Added a feature to apply middleware per schema.

```php
/**
 * Any middleware for a specific 'graphql' schema
 */
'middleware_schema' => [
    'default' => ['auth.basic'],
],
```

Possible solution for #191 