### PR TITLE
Register additional type make commands as artisan commands

### DIFF
--- a/src/Folklore/GraphQL/Console/EnumMakeCommand.php
+++ b/src/Folklore/GraphQL/Console/EnumMakeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace Folklore\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Folklore/GraphQL/Console/FieldMakeCommand.php
+++ b/src/Folklore/GraphQL/Console/FieldMakeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace Folklore\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Config;

--- a/src/Folklore/GraphQL/Console/InterfaceMakeCommand.php
+++ b/src/Folklore/GraphQL/Console/InterfaceMakeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace Folklore\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Config;

--- a/src/Folklore/GraphQL/Console/ScalarMakeCommand.php
+++ b/src/Folklore/GraphQL/Console/ScalarMakeCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace Folklore\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Config;

--- a/src/Folklore/GraphQL/ServiceProvider.php
+++ b/src/Folklore/GraphQL/ServiceProvider.php
@@ -200,6 +200,10 @@ class ServiceProvider extends BaseServiceProvider
         $this->commands(Console\TypeMakeCommand::class);
         $this->commands(Console\QueryMakeCommand::class);
         $this->commands(Console\MutationMakeCommand::class);
+        $this->commands(Console\EnumMakeCommand::class);
+        $this->commands(Console\FieldMakeCommand::class);
+        $this->commands(Console\InterfaceMakeCommand::class);
+        $this->commands(Console\ScalarMakeCommand::class);
     }
 
     /**


### PR DESCRIPTION
This registers the newly added `Enum`/`Field`/`Interface`/`Scalar` type make commands to the artisan command lists like existing `TypeMakeCommand`.