### PR TITLE
Allowing field to be specified as a class combining with a resolver

### DIFF
--- a/src/Folklore/GraphQL/Support/Type.php
+++ b/src/Folklore/GraphQL/Support/Type.php
@@ -57,10 +57,25 @@ class Type extends Fluent
                 $field->name = $name;
                 $allFields[$name] = $field->toArray();
             } else {
+
                 $resolver = $this->getFieldResolver($name, $field);
+
+                if (isset($field['class'])) {
+
+                    $field = $field['class'];
+
+                    if (is_string($field)) {
+                        $field = app($field);
+                    }
+
+                    $field->name = $name;
+                    $field = $field->toArray();
+                }
+
                 if ($resolver) {
                     $field['resolve'] = $resolver;
                 }
+
                 $allFields[$name] = $field;
             }
         }


### PR DESCRIPTION
I encountered a situation where I wanted to use a field multiple times but resolve a different data set for each instance. This does not break any existing functionality, it merely adds more flexibility.

```php
'user' => UserField::class, // Resolves itself

'language_from' => [
    'class' => LanguageField::class,
    'resolve' => function ($root, $args) {
        return $root->translatableFrom;
    }
],

'language_to' => [
    'class' => LanguageField::class,
    'resolve' => function ($root, $args) {
        return $root->translatableTo;
    }
],
```