### PR TITLE
Ensuring graphiql does not get the schema middleware

### DIFF
--- a/src/Folklore/GraphQL/GraphQLController.php
+++ b/src/Folklore/GraphQL/GraphQLController.php
@@ -13,6 +13,10 @@ class GraphQLController extends Controller
             $schema = array_get($route, '2.graphql_schema', $defaultSchema);
         } elseif (is_object($route)) {
             $schema = $route->parameter('graphql_schema', $defaultSchema);
+
+            if ($route->getAction()['controller'] == config('graphql.graphiql.controller')) {
+                $schema = null;
+            }
         } else {
             $schema = $defaultSchema;
         }


### PR DESCRIPTION
Using the default setup, graphiql routes were given the default middleware - which is not expected. This PR does a check on the route to make sure we are not hitting the controller for graphiql.