### PR TITLE
Allows GraphiQLComposer to be overridden in config

### DIFF
--- a/src/Folklore/GraphQL/ServiceProvider.php
+++ b/src/Folklore/GraphQL/ServiceProvider.php
@@ -122,7 +122,8 @@ class ServiceProvider extends BaseServiceProvider
 
         if ($config->get('graphql.graphiql', true)) {
             $view = $config->get('graphql.graphiql.view', 'graphql::graphiql');
-            $this->app['view']->composer($view, View\GraphiQLComposer::class);
+            $composer = $config->get('graphql.graphiql.composer', View\GraphiQLComposer::class);
+            $this->app['view']->composer($view, $composer);
         }
     }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -81,7 +81,8 @@ return [
         'routes' => '/graphiql/{graphql_schema?}',
         'controller' => \Folklore\GraphQL\GraphQLController::class.'@graphiql',
         'middleware' => [],
-        'view' => 'graphql::graphiql'
+        'view' => 'graphql::graphiql',
+        'composer' => \Folklore\GraphQL\View\GraphiQLComposer::class,
     ],
 
     /*


### PR DESCRIPTION
We have a need to be able to override the GraphiQLComposer. Made the following changes:

1. Added a new config parameter called 'composer' under the 'graphql.graphiql' section of config.
2. Updated the ServiceProvider to read the config or fall back to the default if config value doesn't exist.