### PR TITLE
Route can be an array instead of object

### DIFF
--- a/src/Folklore/GraphQL/GraphQLController.php
+++ b/src/Folklore/GraphQL/GraphQLController.php
@@ -9,8 +9,21 @@ class GraphQLController extends Controller
     {
         $route = $request->route();
 
-        // Prevent schema middlewares to be applied to graphiql routes
-        $routeName = is_object($route) ? $route->getName() : null;
+        /** 
+         * Prevent schema middlewares to be applied to graphiql routes
+         *
+         * Be careful !! For Lumen < 5.6, Request->route() returns an array with
+         * 'as' key for named routes
+         *
+         * @see https://github.com/laravel/lumen-framework/issues/119
+         * @see https://laravel.com/api/5.5/Illuminate/Http/Request.html#method_route
+         */
+        $routeName = is_object($route)
+          ? $route->getName()
+          : (is_array($route) && isset($route['as'])
+            ? $route['as']
+            : null);
+
         if (!is_null($routeName) && preg_match('/^graphql\.graphiql/', $routeName)) {
             return;
         }

--- a/src/Folklore/GraphQL/GraphQLController.php
+++ b/src/Folklore/GraphQL/GraphQLController.php
@@ -19,10 +19,10 @@ class GraphQLController extends Controller
          * @see https://laravel.com/api/5.5/Illuminate/Http/Request.html#method_route
          */
         $routeName = is_object($route)
-          ? $route->getName()
-          : (is_array($route) && isset($route['as'])
-            ? $route['as']
-            : null);
+            ? $route->getName()
+            : (is_array($route) && isset($route['as'])
+                ? $route['as']
+                : null);
 
         if (!is_null($routeName) && preg_match('/^graphql\.graphiql/', $routeName)) {
             return;

--- a/src/Folklore/GraphQL/View/GraphiQLComposer.php
+++ b/src/Folklore/GraphQL/View/GraphiQLComposer.php
@@ -15,10 +15,10 @@ class GraphiQLComposer
             $hasRoute = false;
         }
 
-        $schema = $view->schema;
+        $schema = $view->graphql_schema;
 
         if (! empty($schema)) {
-            $view->graphqlPath = $hasRoute ? route('graphql.query', [$schema]) : url('/graphql/' . $schema);
+            $view->graphqlPath = $hasRoute ? route('graphql.query', ['graphql_schema' => $schema]) : url('/graphql/' . $schema);
         } else {
             $view->graphqlPath = $hasRoute ? route('graphql.query') : url('/graphql');
         }


### PR DESCRIPTION
Better Lumen support,

It seems the `Request->route()` returns an array and not an instance of \Illuminate\Routing\Route.
[See this issue (fixed in future release of Lumen)](https://github.com/laravel/lumen-framework/issues/119)

Also specified in [documentation](https://laravel.com/api/5.5/Illuminate/Http/Request.html#method_route)

Middlewares of graphql and its schemas are applied to GraphiQL routes, but that's not what we expect.
