### PR TITLE
+fix: arguments support

### DIFF
--- a/src/Folklore/GraphQL/Support/Traits/ShouldValidate.php
+++ b/src/Folklore/GraphQL/Support/Traits/ShouldValidate.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\WrappingType;
 
 trait ShouldValidate
 {
-    protected function rules($root, $args)
+    public function rules($root = NULL, $args = NULL)
     {
         return [];
     }
@@ -19,6 +19,7 @@ trait ShouldValidate
         $arguments = func_get_args();
 
         $rules = call_user_func_array([$this, 'rules'], $arguments);
+
         $argsRules = [];
         foreach ($this->args() as $name => $arg) {
             if (isset($arg['rules'])) {

--- a/src/Folklore/GraphQL/Support/Traits/ShouldValidate.php
+++ b/src/Folklore/GraphQL/Support/Traits/ShouldValidate.php
@@ -9,7 +9,7 @@ use GraphQL\Type\Definition\WrappingType;
 
 trait ShouldValidate
 {
-    protected function rules()
+    protected function rules($root, $args)
     {
         return [];
     }

--- a/tests/Objects/UpdateExampleMutation.php
+++ b/tests/Objects/UpdateExampleMutation.php
@@ -16,7 +16,7 @@ class UpdateExampleMutation extends Mutation
         return GraphQL::type('Example');
     }
 
-    public function rules()
+    public function rules($root = NULL, $args = NULL)
     {
         return [
             'test' => ['required']
@@ -40,7 +40,7 @@ class UpdateExampleMutation extends Mutation
             'test_with_rules_closure' => [
                 'name' => 'test',
                 'type' => Type::string(),
-                'rules' => function () {
+                'rules' => function ($root, $args) {
                     return ['required'];
                 }
             ],

--- a/tests/Objects/UpdateExampleMutationWithInputType.php
+++ b/tests/Objects/UpdateExampleMutationWithInputType.php
@@ -16,7 +16,7 @@ class UpdateExampleMutationWithInputType extends Mutation
         return GraphQL::type('Example');
     }
 
-    public function rules()
+    public function rules($root = NULL, $args = NULL)
     {
         return [
             'test' => ['required']
@@ -40,7 +40,7 @@ class UpdateExampleMutationWithInputType extends Mutation
             'test_with_rules_closure' => [
                 'name' => 'test',
                 'type' => Type::string(),
-                'rules' => function () {
+                'rules' => function ($root = NULL, $args = NULL) {
                     return ['required'];
                 }
             ],


### PR DESCRIPTION
Adding arguments to the rules function we can have more control over the rules and support something like this:
```
protected function rules($root, $args)
    {
        return [
            'id' => ['required', 'exists:domains,id'],
            'domain' => ['required', Rule::unique('domains')->ignore($args['id'], 'id')]
        ];
    }
```
Without $args['id'] we cannot create that rule easily.