### PR TITLE
Define custom scalars with an interface

### DIFF
--- a/src/Folklore/GraphQL/Console/stubs/scalar.stub
+++ b/src/Folklore/GraphQL/Console/stubs/scalar.stub
@@ -2,27 +2,29 @@
 
 namespace DummyNamespace;
 
+use Folklore\GraphQL\Support\Contracts\TypeConvertible;
 use GraphQL\Type\Definition\ScalarType;
 
-class DummyClass extends ScalarType {
-   /**
-    * @var string
-    */
-   public $name = 'DummyType';
+class DummyClass extends ScalarType implements TypeConvertible
+{
+    /**
+     * @var string
+     */
+    public $name = 'DummyType';
 
-   /**
-    * @var string
-    */
-   public $description = '';
+    /**
+     * @var string
+     */
+    public $description = '';
 
-   /**
-    * @param mixed $value
-    * @return mixed
-    */
-   public function serialize($value)
-   {
-       return $value;
-   }
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    public function serialize($value)
+    {
+        return $value;
+    }
 
     /**
      * @param mixed $value
@@ -40,5 +42,13 @@ class DummyClass extends ScalarType {
     public function parseLiteral($ast)
     {
         return null;
+    }
+
+    /**
+     * @return DummyClass
+     */
+    public function toType()
+    {
+        return new static();
     }
 }

--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -1,5 +1,6 @@
 <?php namespace Folklore\GraphQL;
 
+use Folklore\GraphQL\Support\Contracts\TypeConvertible;
 use GraphQL\GraphQL as GraphQLBase;
 use GraphQL\Schema;
 use GraphQL\Error\Error;
@@ -226,6 +227,10 @@ class GraphQL
     {
         if (!is_object($type)) {
             $type = $this->app->make($type);
+        }
+
+        if (!$type instanceof TypeConvertible) {
+            throw new TypeNotFound(sprintf('Unable to convert %s to a GraphQL type', get_class($type)));
         }
 
         foreach ($opts as $key => $value) {

--- a/src/Folklore/GraphQL/Support/Contracts/TypeConvertible.php
+++ b/src/Folklore/GraphQL/Support/Contracts/TypeConvertible.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Folklore\GraphQL\Support\Contracts;
+
+use GraphQL\Type\Definition\Type;
+
+interface TypeConvertible
+{
+    /**
+     * @return Type
+     */
+    public function toType();
+}

--- a/src/Folklore/GraphQL/Support/Type.php
+++ b/src/Folklore/GraphQL/Support/Type.php
@@ -2,14 +2,14 @@
 
 namespace Folklore\GraphQL\Support;
 
+use Folklore\GraphQL\Support\Contracts\TypeConvertible;
 use GraphQL\Type\Definition\EnumType;
 use Illuminate\Support\Fluent;
 
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\InputObjectType;
-use GraphQL\Type\Definition\InterfaceType;
 
-class Type extends Fluent
+class Type extends Fluent implements TypeConvertible
 {
     protected static $instances = [];
     


### PR DESCRIPTION
This is an attempt at resolving #137. 

I believe to define and use a custom scalar within the config files `types` section, all that we need to do is ensure that the scalar implements a `toType` function. Generally, that function is just constructing the class, but I tried to leave that up to the developer.

Defining the interface also allows for smarter checking during construction of the schema and better error handling. 

Let me know what you think.