### PR TITLE
Fixes issue #198 - different types per schema

### DIFF
--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -58,6 +58,8 @@ class GraphQL
                 ]);
                 $this->typesInstances[$name] = $objectType;
                 $types[] = $objectType;
+                
+                $this->addType($type, $name);
             }
         } else {
             foreach ($this->types as $name => $type) {
@@ -87,10 +89,9 @@ class GraphQL
 
     public function type($name, $fresh = false)
     {
-        // See: https://github.com/Folkloreatelier/laravel-graphql/issues/198#issuecomment-344369081
-        //if (!isset($this->types[$name])) {
-        //    throw new TypeNotFound('Type '.$name.' not found.');
-        //}
+        if (!isset($this->types[$name])) {
+            throw new TypeNotFound('Type '.$name.' not found.');
+        }
 
         if (!$fresh && isset($this->typesInstances[$name])) {
             return $this->typesInstances[$name];

--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -87,9 +87,10 @@ class GraphQL
 
     public function type($name, $fresh = false)
     {
-        if (!isset($this->types[$name])) {
-            throw new TypeNotFound('Type '.$name.' not found.');
-        }
+        // See: https://github.com/Folkloreatelier/laravel-graphql/issues/198#issuecomment-344369081
+        //if (!isset($this->types[$name])) {
+        //    throw new TypeNotFound('Type '.$name.' not found.');
+        //}
 
         if (!$fresh && isset($this->typesInstances[$name])) {
             return $this->typesInstances[$name];


### PR DESCRIPTION
Fixes #198 

As mentioned by @leehicks in the issue #198 there is a bug preventing us from using separate types per schema.

```php
'schemas' => [
    'default' => [
        'query' => [
            'TestQuery' => \App\GraphQL\Query\TestQuery::class,
        ],
        'mutation' => [

        ],
        'types' => [
            'TestType' => \App\GraphQL\Type\TestType::class,
        ],
    ]
],
```