### PR TITLE
authenticate per query or mutation instead of middleware

### DIFF
--- a/tests/GraphQLQueryTest.php
+++ b/tests/GraphQLQueryTest.php
@@ -115,6 +115,18 @@ class GraphQLQueryTest extends TestCase
     }
 
     /**
+     * Test query with authorize
+     *
+     * @test
+     */
+    public function testQueryAndReturnResultWithAuthenticated()
+    {
+        $result = GraphQL::query($this->queries['examplesWithAuthenticated']);
+        $this->assertNull($result['data']['examplesAuthenticated']);
+        $this->assertEquals('Unauthenticated', $result['errors'][0]['message']);
+    }
+
+    /**
      * Test query with schema
      *
      * @test

--- a/tests/Objects/ExamplesAuthenticatedQuery.php
+++ b/tests/Objects/ExamplesAuthenticatedQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+use GraphQL\Type\Definition\Type;
+use Folklore\GraphQL\Support\Query;
+
+class ExamplesAuthenticatedQuery extends ExamplesQuery
+{
+    protected $attributes = [
+        'name' => 'Examples authenticate query'
+    ];
+
+    public function authenticated($root, $args, $context)
+    {
+        return false;
+    }
+}

--- a/tests/Objects/queries.php
+++ b/tests/Objects/queries.php
@@ -43,6 +43,14 @@ return [
         }
     ",
 
+    'examplesWithAuthenticated' =>  "
+        query QueryExamplesAuthenticated {
+            examplesAuthenticated {
+                test
+            }
+        }
+    ",
+
     'examplesWithRoot' =>  "
         query QueryExamplesRoot {
             examplesRoot {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,7 +25,8 @@ class TestCase extends BaseTestCase
                 'examples' => ExamplesQuery::class,
                 'examplesContext' => ExamplesContextQuery::class,
                 'examplesRoot' => ExamplesRootQuery::class,
-                'examplesAuthorize' => ExamplesAuthorizeQuery::class
+                'examplesAuthorize' => ExamplesAuthorizeQuery::class,
+                'examplesAuthenticated' => ExamplesAuthenticatedQuery::class,
             ],
             'mutation' => [
                 'updateExample' => UpdateExampleMutation::class


### PR DESCRIPTION
Currently we can authenticate with middleware where we have different schema for guest and authenticated user. This works fine but its better to have this control in each query or mutation and having one schema.

For example lets say we have a query where we want current user info and latest 5 post in one query.
`post` query is public and `me` requires authentication.  

```
query currentUserAndPublicPosts {
  me {
    id
    name
    email
  }
  post(first: 5) {
    name
    category
    createdAt
  }
}
``` 

I do not see the above query working by having multiple schema of guest and authenticated user.

With this PR we will be able to check authentication per query or mutation by adding following to the query or mutation.

```php
    public function authenticated($root, $args, $currentUser)
    {
        return $currentUser && $currentUser->id !== null;
    }
```