### PR TITLE
Customizing the validation error messages and fixed arguments

### DIFF
--- a/src/Folklore/GraphQL/Support/Traits/ShouldValidate.php
+++ b/src/Folklore/GraphQL/Support/Traits/ShouldValidate.php
@@ -14,6 +14,16 @@ trait ShouldValidate
         return [];
     }
 
+    /**
+     * Return an array of custom validation error messages.
+     *
+     * @return array
+     */
+    public function validationErrorMessages($root, $args, $context)
+    {
+        return [];
+    }
+
     public function getRules()
     {
         $arguments = func_get_args();
@@ -87,9 +97,9 @@ trait ShouldValidate
         return $rules;
     }
 
-    protected function getValidator($args, $rules)
+    protected function getValidator($args, $rules, $messages = [])
     {
-        return app('validator')->make($args, $rules);
+        return app('validator')->make($args, $rules, $messages);
     }
 
     protected function getResolver()
@@ -103,9 +113,10 @@ trait ShouldValidate
             $arguments = func_get_args();
 
             $rules = call_user_func_array([$this, 'getRules'], $arguments);
+            $validationErrorMessages = call_user_func_array([$this, 'validationErrorMessages'], $arguments);
             if (sizeof($rules)) {
                 $args = array_get($arguments, 1, []);
-                $validator = $this->getValidator($args, $rules);
+                $validator = $this->getValidator($args, $rules, $validationErrorMessages);
                 if ($validator->fails()) {
                     throw with(new ValidationError('validation'))->setValidator($validator);
                 }

--- a/tests/MutationTest.php
+++ b/tests/MutationTest.php
@@ -1,8 +1,5 @@
 <?php
 
-use Folklore\Support\Field;
-use GraphQL\Type\Definition\Type;
-use GraphQL\Type\Definition\ObjectType;
 use Illuminate\Validation\Validator;
 
 class MutationTest extends FieldTest
@@ -24,7 +21,7 @@ class MutationTest extends FieldTest
     }
 
     /**
-     * Test get rules
+     * Test get rules.
      *
      * @test
      */
@@ -50,7 +47,7 @@ class MutationTest extends FieldTest
     }
 
     /**
-     * Test resolve
+     * Test resolve.
      *
      * @test
      */
@@ -80,7 +77,7 @@ class MutationTest extends FieldTest
     }
 
     /**
-     * Test resolve throw validation error
+     * Test resolve throw validation error.
      *
      * @test
      * @expectedException \Folklore\GraphQL\Error\ValidationError
@@ -95,7 +92,7 @@ class MutationTest extends FieldTest
     }
 
     /**
-     * Test validation error
+     * Test validation error.
      *
      * @test
      */
@@ -120,6 +117,31 @@ class MutationTest extends FieldTest
             $this->assertTrue($messages->has('test_with_rules_input_object.val'));
             $this->assertTrue($messages->has('test_with_rules_input_object.nest'));
             $this->assertTrue($messages->has('test_with_rules_input_object.list'));
+        }
+    }
+
+    /**
+     * Test custom validation error messages.
+     *
+     * @test
+     */
+    public function testCustomValidationErrorMessages()
+    {
+        $class = $this->getFieldClass();
+        $field = new $class();
+        $rules = $field->getRules();
+        $attributes = $field->getAttributes();
+        try {
+            $attributes['resolve'](null, [
+                 'test_with_rules_input_object' => [
+                     'nest' => ['email' => 'invalidTestEmail.com'],
+                 ],
+             ], [], null);
+        } catch (\Folklore\GraphQL\Error\ValidationError $e) {
+            $messages = $e->getValidatorMessages();
+
+            $this->assertEquals($messages->first('test'), 'A test is required.');
+            $this->assertEquals($messages->first('test_with_rules_input_object.nest.email'), 'Invalid your email : invalidTestEmail.com');
         }
     }
 }

--- a/tests/Objects/UpdateExampleMutationWithInputType.php
+++ b/tests/Objects/UpdateExampleMutationWithInputType.php
@@ -6,9 +6,8 @@ use GraphQL\Type\Definition\Type;
 
 class UpdateExampleMutationWithInputType extends Mutation
 {
-
     protected $attributes = [
-        'name' => 'updateExample'
+        'name' => 'updateExample',
     ];
 
     public function type()
@@ -19,8 +18,18 @@ class UpdateExampleMutationWithInputType extends Mutation
     public function rules()
     {
         return [
-            'test' => ['required']
+            'test' => ['required'],
         ];
+    }
+
+    public function validationErrorMessages($root, $args, $context)
+    {
+        $inavlidEmail = array_get($args, 'test_with_rules_input_object.nest.email');
+
+        return [
+             'test.required' => 'A test is required.',
+             'test_with_rules_input_object.nest.email.email' => 'Invalid your email : '.$inavlidEmail,
+          ];
     }
 
     public function args()
@@ -28,13 +37,13 @@ class UpdateExampleMutationWithInputType extends Mutation
         return [
             'test' => [
                 'name' => 'test',
-                'type' => Type::string()
+                'type' => Type::string(),
             ],
 
             'test_with_rules' => [
                 'name' => 'test',
                 'type' => Type::string(),
-                'rules' => ['required']
+                'rules' => ['required'],
             ],
 
             'test_with_rules_closure' => [
@@ -42,7 +51,7 @@ class UpdateExampleMutationWithInputType extends Mutation
                 'type' => Type::string(),
                 'rules' => function () {
                     return ['required'];
-                }
+                },
             ],
 
             'test_with_rules_input_object' => [
@@ -56,7 +65,7 @@ class UpdateExampleMutationWithInputType extends Mutation
     public function resolve($root, $args)
     {
         return [
-            'test' => array_get($args, 'test')
+            'test' => array_get($args, 'test'),
         ];
     }
 }


### PR DESCRIPTION
Fixed missing arguments in the ``validationErrorMessages`` method. #261 

We can have more control to compute the validation messages.

For example :
```php
public function validationErrorMessages($root, $args, $context)
    {
        $inavlidEmail = array_get($args, 'test_with_rules_input_object.nest.email');

        return [
             'test.required' => 'A test is required.',
             'test_with_rules_input_object.nest.email.email' => 'Invalid your email : '.$inavlidEmail,
          ];
    }
```
@dmongeau  Thank you !
