### PR TITLE
Deprecated: `GraphQL\Schema` moved to `GraphQL\Type\Schema`

### DIFF
--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -2,7 +2,7 @@
 
 use Folklore\GraphQL\Support\Contracts\TypeConvertible;
 use GraphQL\GraphQL as GraphQLBase;
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Error\Error;
 
 use GraphQL\Type\Definition\ObjectType;

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -100,7 +100,7 @@ return [
     /*
      * The schemas for query and/or mutation. It expects an array to provide
      * both the 'query' fields and the 'mutation' fields. You can also
-     * provide an GraphQL\Schema object directly.
+     * provide an GraphQL\Type\Schema object directly.
      *
      * Example:
      *

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Validator\DocumentValidator;
 

--- a/tests/EndpointTest.php
+++ b/tests/EndpointTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 
 class EndpointTest extends TestCase

--- a/tests/GraphQLQueryTest.php
+++ b/tests/GraphQLQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Error\Error;

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Error\Error;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,7 @@ class TestCase extends BaseTestCase
 
     protected function assertGraphQLSchema($schema)
     {
-        $this->assertInstanceOf('GraphQL\Schema', $schema);
+        $this->assertInstanceOf('GraphQL\Type\Schema', $schema);
     }
 
     protected function assertGraphQLSchemaHasQuery($schema, $key)


### PR DESCRIPTION
webonyx/graphql-php uses the new GraphQL\Type\Schema and not the old one.

Especially useful when using BuildSchema to build a schema, which builds the schema using the new class.