### PR TITLE
Added custom resolver feature

### DIFF
--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -2,7 +2,7 @@
 
 use Folklore\GraphQL\Support\Contracts\TypeConvertible;
 use GraphQL\GraphQL as GraphQLBase;
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Error\Error;
 
 use GraphQL\Type\Definition\ObjectType;

--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -43,7 +43,11 @@ class GraphQL
             throw new SchemaNotFound('Type '.$schemaName.' not found.');
         }
 
-        $schema = is_array($schema) ? $schema:$this->schemas[$schemaName];
+        $schema = is_array($schema) ? $schema : $this->schemas[$schemaName];
+
+        if ($schema instanceof Schema) {
+            return $schema;
+        }
 
         $schemaQuery = array_get($schema, 'query', []);
         $schemaMutation = array_get($schema, 'mutation', []);
@@ -152,10 +156,13 @@ class GraphQL
 
     public function queryAndReturnResult($query, $variables = [], $opts = [])
     {
-        $root = array_get($opts, 'root', null);
         $context = array_get($opts, 'context', null);
         $schemaName = array_get($opts, 'schema', null);
         $operationName = array_get($opts, 'operationName', null);
+
+        $additionalResolversSchemaName = is_string($schemaName) ? $schemaName : config('graphql.schema', 'default');
+        $additionalResolvers = config('graphql.resolvers.' . $additionalResolversSchemaName, []);
+        $root = array_merge(array_get($opts, 'root', []), $additionalResolvers);
 
         $schema = $this->schema($schemaName);
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -100,7 +100,7 @@ return [
     /*
      * The schemas for query and/or mutation. It expects an array to provide
      * both the 'query' fields and the 'mutation' fields. You can also
-     * provide an GraphQL\Schema object directly.
+     * provide an GraphQL\Type\Schema object directly.
      *
      * Example:
      *

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -133,6 +133,25 @@ return [
     ],
 
     /*
+     * Additional resolvers which can also be used with shorthand building of the schema
+     * using \GraphQL\Utils::BuildSchema feature
+     *
+     * Example:
+     *
+     * 'resolvers' => [
+     *     'default' => [
+     *         'echo' => function ($root, $args, $context) {
+     *              return 'Echo: ' . $args['message'];
+     *          },
+     *     ],
+     * ],
+     */
+    'resolvers' => [
+        'default' => [
+        ],
+    ],
+
+    /*
      * The types available in the application. You can access them from the
      * facade like this: GraphQL::type('user')
      *

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Validator\DocumentValidator;
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use GraphQL\Type\Schema;
+use GraphQL\Utils\BuildSchema;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Validator\DocumentValidator;
 
@@ -39,7 +40,24 @@ class ConfigTest extends TestCase
                     'mutation' => [
                         'updateExampleCustom' => UpdateExampleMutation::class
                     ]
-                ]
+                ],
+                'shorthand' => BuildSchema::build('
+                    schema {
+                        query: ShorthandExample
+                    }
+
+                    type ShorthandExample {
+                        echo(message: String!): String!
+                    }
+                '),
+            ],
+
+            'resolvers' => [
+                'shorthand' => [
+                    'echo' => function ($root, $args, $context) {
+                        return 'Echo: ' . $args['message'];
+                    },
+                ],
             ],
 
             'types' => [
@@ -100,6 +118,7 @@ class ConfigTest extends TestCase
 
         $this->assertArrayHasKey('default', $schemas);
         $this->assertArrayHasKey('custom', $schemas);
+        $this->assertArrayHasKey('shorthand', $schemas);
     }
 
     public function testVariablesInputName()
@@ -119,6 +138,24 @@ class ConfigTest extends TestCase
             'examples' => [
                 $this->data[0]
             ]
+        ]);
+    }
+
+    public function testVariablesInputNameForShorthandResolver()
+    {
+        $response = $this->call('GET', '/graphql_test/query/shorthand', [
+            'query' => $this->queries['shorthandExamplesWithVariables'],
+            'params' => [
+                'message' => 'Hello World!',
+            ],
+        ]);
+
+        $this->assertEquals($response->getStatusCode(), 200);
+
+        $content = $response->getData(true);
+        $this->assertArrayHasKey('data', $content);
+        $this->assertEquals($content['data'], [
+            'echo' => 'Echo: Hello World!',
         ]);
     }
 

--- a/tests/EndpointTest.php
+++ b/tests/EndpointTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 
 class EndpointTest extends TestCase

--- a/tests/GraphQLQueryTest.php
+++ b/tests/GraphQLQueryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Error\Error;

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GraphQL\Schema;
+use GraphQL\Type\Schema;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Error\Error;

--- a/tests/Objects/queries.php
+++ b/tests/Objects/queries.php
@@ -27,6 +27,12 @@ return [
         }
     ",
 
+    'shorthandExamplesWithVariables' =>  "
+        query QueryShorthandExamplesVariables(\$message: String!) {
+            echo(message: \$message)
+        }
+    ",
+
     'examplesWithContext' =>  "
         query QueryExamplesContext {
             examplesContext {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,7 @@ class TestCase extends BaseTestCase
 
     protected function assertGraphQLSchema($schema)
     {
-        $this->assertInstanceOf('GraphQL\Schema', $schema);
+        $this->assertInstanceOf('GraphQL\Type\Schema', $schema);
     }
 
     protected function assertGraphQLSchemaHasQuery($schema, $key)


### PR DESCRIPTION
Custom resolvers are needed if Schema is build using \GraphQL\Utils::BuildSchema.

This would make the shorthand example usable, see https://github.com/webonyx/graphql-php/tree/master/examples/02-shorthand