### PR TITLE
Add defaultFieldResolver feature with new executeQuery call

### DIFF
--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -159,14 +159,15 @@ class GraphQL
         $context = array_get($opts, 'context', null);
         $schemaName = array_get($opts, 'schema', null);
         $operationName = array_get($opts, 'operationName', null);
+        $defaultFieldResolver = config('graphql.defaultFieldResolver', null);
 
         $additionalResolversSchemaName = is_string($schemaName) ? $schemaName : config('graphql.schema', 'default');
         $additionalResolvers = config('graphql.resolvers.' . $additionalResolversSchemaName, []);
-        $root = array_merge(array_get($opts, 'root', []), $additionalResolvers);
+        $root = is_array($additionalResolvers) ? array_merge(array_get($opts, 'root', []), $additionalResolvers) : $additionalResolvers;
 
         $schema = $this->schema($schemaName);
 
-        $result = GraphQLBase::executeAndReturnResult($schema, $query, $root, $context, $variables, $operationName);
+        $result = GraphQLBase::executeQuery($schema, $query, $root, $context, $variables, $operationName, $defaultFieldResolver);
 
         return $result;
     }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -152,6 +152,19 @@ return [
     ],
 
     /*
+     * Overrides the default field resolver
+     * Useful to setup default loading of eager relationships
+     *
+     * Example:
+     *
+     * 'defaultFieldResolver' => function ($root, $args, $context, $info) {
+     *     // take a look at the defaultFieldResolver in
+     *     // https://github.com/webonyx/graphql-php/blob/master/src/Executor/Executor.php
+     * },
+     */
+    'defaultFieldResolver' => null,
+
+    /*
      * The types available in the application. You can access them from the
      * facade like this: GraphQL::type('user')
      *


### PR DESCRIPTION
Currently executeAndReturnResult() will be used to execute the query. But it's deprecated. The new one is executeQuery and it supports overriding the defaultFieldResolver too.