### PR TITLE
Add $context and $info to authorize method

### DIFF
--- a/src/Folklore/GraphQL/Support/Field.php
+++ b/src/Folklore/GraphQL/Support/Field.php
@@ -4,6 +4,7 @@ namespace Folklore\GraphQL\Support;
 
 use Illuminate\Support\Fluent;
 use Folklore\GraphQL\Error\AuthorizationError;
+use Folklore\GraphQL\Type\Definition\ResolveInfo;
 
 class Field extends Fluent
 {
@@ -12,7 +13,7 @@ class Field extends Fluent
      * Override this in your queries or mutations
      * to provide custom authorization
      */
-    public function authorize($root, $args)
+    public function authorize($root, $args, $context, ResolveInfo $info)
     {
         return true;
     }

--- a/src/Folklore/GraphQL/Support/Field.php
+++ b/src/Folklore/GraphQL/Support/Field.php
@@ -12,6 +12,13 @@ class Field extends Fluent
     /**
      * Override this in your queries or mutations
      * to provide custom authorization
+     *
+     * @param $root
+     * @param array $args
+     * @param array $context
+     * @param ResolveInfo $info
+     *
+     * @return boolean
      */
     public function authorize($root, $args, $context, ResolveInfo $info)
     {

--- a/tests/Objects/ExamplesAuthorizeQuery.php
+++ b/tests/Objects/ExamplesAuthorizeQuery.php
@@ -2,6 +2,7 @@
 
 use GraphQL\Type\Definition\Type;
 use Folklore\GraphQL\Support\Query;
+use Folklore\GraphQL\Type\Definition\ResolveInfo;
 
 class ExamplesAuthorizeQuery extends ExamplesQuery
 {
@@ -9,7 +10,7 @@ class ExamplesAuthorizeQuery extends ExamplesQuery
         'name' => 'Examples authorize query'
     ];
 
-    public function authorize($root, $args)
+    public function authorize($root, $args, $context, ResolveInfo $info)
     {
         return false;
     }


### PR DESCRIPTION
I have added these 2 missing arguments in order to access the $info in the authorize method.