### PR TITLE
Add a configuration option to suppress the 'TypeAdded' event

### DIFF
--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -183,14 +183,18 @@ class GraphQL
         $name = $this->getTypeName($class, $name);
         $this->types[$name] = $class;
 
-        event(new TypeAdded($class, $name));
+        if (config('graphql.fire_events', true) === true) {
+            event(new TypeAdded($class, $name));
+        }
     }
 
     public function addSchema($name, $schema)
     {
         $this->schemas[$name] = $schema;
 
-        event(new SchemaAdded($schema, $name));
+        if (config('graphql.fire_events', true) === true) {
+            event(new SchemaAdded($schema, $name));
+        }
     }
 
     public function clearType($name)

--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -29,7 +29,7 @@ class GraphQL
     public function __construct($app)
     {
         $this->app = $app;
-        $this->fireEvents = config('graphql.fire_events', true);
+        $this->fireTypeAddedEvent = config('graphql.fire_type_added_events', true);
     }
 
     public function schema($schema = null)
@@ -186,18 +186,14 @@ class GraphQL
         $name = $this->getTypeName($class, $name);
         $this->types[$name] = $class;
 
-        if ($this->fireEvents === true) {
+        if ($this->fireTypeAddedEvent === true) {
             event(new TypeAdded($class, $name));
         }
     }
 
     public function addSchema($name, $schema)
     {
-        $this->schemas[$name] = $schema;
-
-        if ($this->fireEvents === true) {
-            event(new SchemaAdded($schema, $name));
-        }
+        event(new SchemaAdded($schema, $name));
     }
 
     public function clearType($name)

--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -24,9 +24,12 @@ class GraphQL
     protected $types = [];
     protected $typesInstances = [];
 
+    private $fireEvents = true;
+
     public function __construct($app)
     {
         $this->app = $app;
+        $this->fireEvents = config('graphql.fire_events', true);
     }
 
     public function schema($schema = null)
@@ -183,7 +186,7 @@ class GraphQL
         $name = $this->getTypeName($class, $name);
         $this->types[$name] = $class;
 
-        if (config('graphql.fire_events', true) === true) {
+        if ($this->fireEvents === true) {
             event(new TypeAdded($class, $name));
         }
     }
@@ -192,7 +195,7 @@ class GraphQL
     {
         $this->schemas[$name] = $schema;
 
-        if (config('graphql.fire_events', true) === true) {
+        if ($this->fireEvents === true) {
             event(new SchemaAdded($schema, $name));
         }
     }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -91,6 +91,11 @@ return [
     ],
 
     /*
+     * Whether or not to fire events such as TypeAdded, SchemaAdded, etc.
+     */
+    'fire_events' => false,
+
+    /*
      * The name of the default schema used when no arguments are provided
      * to GraphQL::schema() or when the route is used without the graphql_schema
      * parameter

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -91,9 +91,9 @@ return [
     ],
 
     /*
-     * Whether or not to fire events such as TypeAdded, SchemaAdded, etc.
+     * Whether or not to fire the 'TypeAdded' event. You can set this to false if you don't use it in your application.
      */
-    'fire_events' => false,
+    'fire_type_added_events' => false,
 
     /*
      * The name of the default schema used when no arguments are provided


### PR DESCRIPTION
I'm building a pretty large application using this library, and I currently register 500+ types. As each type is registered, it individually fires a 'TypeAdded' event, which is not actually used by the library. Profiling this with Blackfire, I found that this event firing was added 10+ ms to my boot time, so I added a flag in the configuration options to suppress it, defaulting to `true` so the behavior is unchanged unless you toggle this flag.

If the event is truly not being used, it may be better to just remove it, but I don't know if anyone is using it externally.