### PR TITLE
Add input-object as an option, to the type make command.

### DIFF
--- a/src/Folklore/GraphQL/Console/TypeMakeCommand.php
+++ b/src/Folklore/GraphQL/Console/TypeMakeCommand.php
@@ -3,7 +3,6 @@
 namespace Folklore\GraphQL\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Symfony\Component\Console\Input\InputOption;
 
 class TypeMakeCommand extends GeneratorCommand
 {
@@ -12,7 +11,9 @@ class TypeMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'make:graphql:type {name}';
+    protected $signature = 'make:graphql:type 
+                            {name : The name of the type class}
+                            {--O|object : Create a new input object type}';
 
     /**
      * The console command description.
@@ -41,7 +42,8 @@ class TypeMakeCommand extends GeneratorCommand
     /**
      * Get the default namespace for the class.
      *
-     * @param  string  $rootNamespace
+     * @param string $rootNamespace
+     *
      * @return string
      */
     protected function getDefaultNamespace($rootNamespace)
@@ -52,7 +54,8 @@ class TypeMakeCommand extends GeneratorCommand
     /**
      * Build the class with the given name.
      *
-     * @param  string  $name
+     * @param string $name
+     *
      * @return string
      */
     protected function buildClass($name)
@@ -65,19 +68,38 @@ class TypeMakeCommand extends GeneratorCommand
     /**
      * Replace the namespace for the given stub.
      *
-     * @param  string  $stub
-     * @param  string  $name
+     * @param string $stub
+     * @param string $name
+     *
      * @return $this
      */
     protected function replaceType($stub, $name)
     {
         preg_match('/([^\\\]+)$/', $name, $matches);
-        $stub = str_replace(
-            'DummyType',
-            $matches[1],
+
+        $search = ['DummyType', 'DummyInputObject'];
+        $replace = [$matches[1]];
+
+        $this->addInputObjectAttribute($replace);
+
+        return str_replace(
+            $search,
+            $replace,
             $stub
         );
+    }
 
-        return $stub;
+    /**
+     * Add input object attribute to replace type.
+     *
+     * @param array $replace
+     */
+    protected function addInputObjectAttribute(array &$replace): void
+    {
+        if ($this->option('object')) {
+            array_push($replace, 'protected $inputObject = true;');
+        } else {
+            array_push($replace, '');
+        }
     }
 }

--- a/src/Folklore/GraphQL/Console/TypeMakeCommand.php
+++ b/src/Folklore/GraphQL/Console/TypeMakeCommand.php
@@ -77,13 +77,12 @@ class TypeMakeCommand extends GeneratorCommand
     {
         preg_match('/([^\\\]+)$/', $name, $matches);
 
-        $search = ['DummyType', 'DummyInputObject'];
         $replace = [$matches[1]];
 
         $this->addInputObjectAttribute($replace);
 
         return str_replace(
-            $search,
+            ['DummyType', 'DummyInputObject'],
             $replace,
             $stub
         );

--- a/src/Folklore/GraphQL/Console/stubs/type.stub
+++ b/src/Folklore/GraphQL/Console/stubs/type.stub
@@ -8,6 +8,7 @@ use GraphQL;
 
 class DummyClass extends BaseType
 {
+    DummyInputObject
     protected $attributes = [
         'name' => 'DummyType',
         'description' => 'A type'
@@ -16,7 +17,10 @@ class DummyClass extends BaseType
     public function fields()
     {
         return [
-            
+              'sampleField' => [
+                'type' => Type::string(),
+                'description' => 'Sample field description',
+            ],
         ];
     }
 }


### PR DESCRIPTION
If you need to create a type of input object, use the option **--object**  to the below command:

```sh
 $ php artisan make:graphql:type <name>  --object 
```

For see more details, use the option **-h**  in the command.