### PR TITLE
Update graphiql to latest version

### DIFF
--- a/src/resources/views/graphiql.php
+++ b/src/resources/views/graphiql.php
@@ -17,7 +17,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.5.4/react-dom.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.3/graphiql.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.js"></script>
     </head>
     <body>
         <div id="graphiql">Loading...</div>


### PR DESCRIPTION
Updates version. This updated version supports markdown on the description of the fields.