### PR TITLE
Added pagination with cursor info

### DIFF
--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -16,6 +16,9 @@ use Folklore\GraphQL\Exception\SchemaNotFound;
 use Folklore\GraphQL\Events\SchemaAdded;
 use Folklore\GraphQL\Events\TypeAdded;
 
+use Folklore\GraphQL\Support\PaginationType;
+use Folklore\GraphQL\Support\PaginationCursorType;
+
 class GraphQL
 {
     protected $app;
@@ -300,5 +303,20 @@ class GraphQL
         }
 
         return $error;
+    }
+
+    public function pagination(ObjectType $type)
+    {
+        // Only add the PaginationCursor when there is a pagination defined.
+        if (!isset($this->types['PaginationCursor'])) {
+            $this->types['PaginationCursor'] = new PaginationCursorType();
+        }
+
+        // If the instace type of the given pagination does not exists, create a new one!
+        if (!isset($this->typesInstances[$type->name . 'Pagination'])) {
+            $this->typesInstances[$type->name . 'Pagination'] = new PaginationType($type->name);
+        }
+
+        return $this->typesInstances[$type->name . 'Pagination'];
     }
 }

--- a/src/Folklore/GraphQL/Support/PaginationCursorType.php
+++ b/src/Folklore/GraphQL/Support/PaginationCursorType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Folklore\GraphQL\Support;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Illuminate\Pagination\LengthAwarePaginator;
+use GraphQL;
+
+class PaginationCursorType extends ObjectType
+{
+    public function __construct()
+    {
+        // See https://laravel.com/api/5.6/Illuminate/Pagination/LengthAwarePaginator.html for more fields.
+        parent::__construct([
+            'name' => 'PaginationCursor',
+            'fields' => [
+                'total' => [
+                    'type' => GraphQLType::nonNull(GraphQLType::int()),
+                    'resolve' => function (LengthAwarePaginator $paginator) {
+                        return $paginator->total();
+                    },
+                ],
+                'perPage' => [
+                    'type' => GraphQLType::nonNull(GraphQLType::int()),
+                    'resolve' => function (LengthAwarePaginator $paginator) {
+                        return $paginator->perPage();
+                    },
+                ],
+                'currentPage' => [
+                    'type' => GraphQLType::nonNull(GraphQLType::int()),
+                    'resolve' => function (LengthAwarePaginator $paginator) {
+                        return $paginator->currentPage();
+                    },
+                ],
+                'hasPages' => [
+                    'type' => GraphQLType::nonNull(GraphQLType::boolean()),
+                    'resolve' => function (LengthAwarePaginator $paginator) {
+                        return $paginator->hasPages();
+                    },
+                ],
+            ],
+        ]);
+    }
+}

--- a/src/Folklore/GraphQL/Support/PaginationType.php
+++ b/src/Folklore/GraphQL/Support/PaginationType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Folklore\GraphQL\Support;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Illuminate\Pagination\LengthAwarePaginator;
+use GraphQL;
+
+class PaginationType extends ObjectType
+{
+    public function __construct(string $type)
+    {
+        parent::__construct([
+            'name' => $type . 'Pagination',
+            'fields' => [
+                'items' => [
+                    'type' => GraphQLType::listOf(GraphQL::type($type)),
+                    'resolve' => function (LengthAwarePaginator $paginator) {
+                        return $paginator->getCollection();
+                    },
+                ],
+                'cursor' => [
+                    'type' => GraphQLType::nonNull(GraphQL::type('PaginationCursor')),
+                    'resolve' => function (LengthAwarePaginator $paginator) {
+                        return $paginator;
+                    },
+                ],
+            ],
+        ]);
+    }
+}

--- a/src/Folklore/GraphQL/Support/PaginationType.php
+++ b/src/Folklore/GraphQL/Support/PaginationType.php
@@ -9,7 +9,7 @@ use GraphQL;
 
 class PaginationType extends ObjectType
 {
-    public function __construct(string $type)
+    public function __construct($type)
     {
         parent::__construct([
             'name' => $type . 'Pagination',

--- a/tests/Objects/ExamplesPaginationQuery.php
+++ b/tests/Objects/ExamplesPaginationQuery.php
@@ -1,0 +1,44 @@
+<?php
+
+use GraphQL\Type\Definition\Type;
+use Folklore\GraphQL\Support\Query;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class ExamplesPaginationQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'examples'
+    ];
+
+    public function type()
+    {
+        return GraphQL::pagination(GraphQL::type('Example'));
+    }
+
+    public function args()
+    {
+        return [
+            'take' => [
+                'type' => Type::nonNull(Type::int()),
+            ],
+            'page' => [
+                'type' => Type::nonNull(Type::int()),
+            ],
+        ];
+    }
+
+    public function resolve($root, $args)
+    {
+        $data = include(__DIR__.'/data.php');
+
+        $take = $args['take'];
+        $page = $args['page'] - 1;
+
+        return new LengthAwarePaginator(
+            collect($data)->slice($page * $take, $take), 
+            count($data), 
+            $take, 
+            $page
+        );
+    }
+}

--- a/tests/Objects/ExamplesPaginationQuery.php
+++ b/tests/Objects/ExamplesPaginationQuery.php
@@ -7,7 +7,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class ExamplesPaginationQuery extends Query
 {
     protected $attributes = [
-        'name' => 'examples'
+        'name' => 'Examples with pagination',
     ];
 
     public function type()

--- a/tests/Objects/queries.php
+++ b/tests/Objects/queries.php
@@ -87,6 +87,22 @@ return [
                 test
             }
         }
-    "
+    ",
+
+    'examplePagination' => "
+        query Items(\$take: Int!, \$page: Int!) {
+            examplesPagination(take: \$take, page: \$page) {
+                items {
+                    test
+                }
+                cursor {
+                    total
+                    perPage
+                    currentPage
+                    hasPages
+                }
+            }
+        }
+    ",
 
 ];

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -9,7 +9,7 @@ class PaginationTest extends FieldTest
      *
      * @test
      */
-    public function testPaginationHasCursor()
+    public function testPagination()
     {
         $take = 2;
         $page = 1;
@@ -21,11 +21,16 @@ class PaginationTest extends FieldTest
         ]);
 
         // Assert
+        $items = $result['data']['examplesPagination']['items'];
         $cursor = $result['data']['examplesPagination']['cursor'];
 
         $this->assertEquals($cursor['total'], count($this->data));
         $this->assertEquals($cursor['perPage'], $take);
         $this->assertEquals($cursor['currentPage'], $page);
         $this->assertEquals($cursor['hasPages'], count($this->data) > $take);
+
+        $this->assertEquals(count($items), $take);
+        $this->assertEquals($items[0]['test'], $this->data[0]['test']);
+        $this->assertEquals($items[1]['test'], $this->data[1]['test']);
     }
 }

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -5,7 +5,7 @@ use Illuminate\Validation\Validator;
 class PaginationTest extends FieldTest
 {
     /**
-     * Test resolve.
+     * Test the pagination type
      *
      * @test
      */

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Validation\Validator;
+
+class PaginationTest extends FieldTest
+{
+    /**
+     * Test resolve.
+     *
+     * @test
+     */
+    public function testPaginationHasCursor()
+    {
+        $take = 2;
+        $page = 1;
+
+        // Act
+        $result = GraphQL::query($this->queries['examplePagination'], [
+            'take' => $take,
+            'page' => $page,
+        ]);
+
+        // Assert
+        $cursor = $result['data']['examplesPagination']['cursor'];
+
+        $this->assertEquals($cursor['total'], count($this->data));
+        $this->assertEquals($cursor['perPage'], $take);
+        $this->assertEquals($cursor['currentPage'], $page);
+        $this->assertEquals($cursor['hasPages'], count($this->data) > $take);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ class TestCase extends BaseTestCase
                 'examplesRoot' => ExamplesRootQuery::class,
                 'examplesAuthorize' => ExamplesAuthorizeQuery::class,
                 'examplesAuthenticated' => ExamplesAuthenticatedQuery::class,
+                'examplesPagination' => ExamplesPaginationQuery::class,
             ],
             'mutation' => [
                 'updateExample' => UpdateExampleMutation::class
@@ -35,7 +36,7 @@ class TestCase extends BaseTestCase
 
         $app['config']->set('graphql.schemas.custom', [
             'query' => [
-                'examplesCustom' => ExamplesQuery::class
+                'examplesCustom' => ExamplesQuery::class,
             ],
             'mutation' => [
                 'updateExampleCustom' => UpdateExampleMutation::class


### PR DESCRIPTION
Created a new implementation of my previous pagination PR (#242).

Example project: https://github.com/kevinvdburgt/laravel-graphql-example/blob/62daca1f6ebe5664afc01488a5b437ab7b6f32bf/app/GraphQL/Query/PostsQuery.php#L20

![screen shot 2018-03-04 at 20 51 59](https://user-images.githubusercontent.com/1987802/36949846-e5a65176-1fed-11e8-85a6-c9720e5efd08.png)

When using the pagination type, for example:
```php
public function type()
{
    return GraphQL::pagination(GraphQL::type('Post'));
}
```
The library will create's a type `PostPagination` and a `PaginationCursor` type when it doesnt exists yet.