### PR TITLE
Fix bug that middleware not work when not using default prefix and default schema

### DIFF
--- a/src/Folklore/GraphQL/GraphQLController.php
+++ b/src/Folklore/GraphQL/GraphQLController.php
@@ -33,9 +33,9 @@ class GraphQLController extends Controller
 
         $defaultSchema = config('graphql.schema');
         if (is_array($route)) {
-            $schema = array_get($route, '2.'.$prefix.'_schema', $defaultSchema);
+            $schema = array_get($route, '2.graphql_schema', $defaultSchema);
         } elseif (is_object($route)) {
-            $schema = $route->parameter($prefix.'_schema', $defaultSchema);
+            $schema = $route->parameter('graphql_schema', $defaultSchema);
         } else {
             $schema = $defaultSchema;
         }


### PR DESCRIPTION
Follow Issue #332 

I'm not sure I should change the routes file or controller.  
But I think that there will be only one schema per request, so I just change the `routes.php`.