### PR TITLE
Only merge root if it is an array

### DIFF
--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -166,7 +166,9 @@ class GraphQL
 
         $additionalResolversSchemaName = is_string($schemaName) ? $schemaName : config('graphql.schema', 'default');
         $additionalResolvers = config('graphql.resolvers.' . $additionalResolversSchemaName, []);
-        $root = is_array($additionalResolvers) ? array_merge(array_get($opts, 'root', []), $additionalResolvers) : $additionalResolvers;
+        $root = array_get($opts, 'root', []);
+        if (is_array($root))
+            $root = is_array($additionalResolvers) ? array_merge($root, $additionalResolvers) : $additionalResolvers;
 
         $schema = $this->schema($schemaName);
 


### PR DESCRIPTION
Reason for change - if root is an eloquent of the change in 1.0.37 broke it. The fix restores so the package again works with Eloquent objects as root.