### PR TITLE
Verify that a type name is specified before overriding class's type name

### DIFF
--- a/src/Folklore/GraphQL/GraphQL.php
+++ b/src/Folklore/GraphQL/GraphQL.php
@@ -67,7 +67,7 @@ class GraphQL
                 $this->typesInstances[$name] = $objectType;
                 $types[] = $objectType;
                 
-                $this->addType($type, $name);
+                $this->addType($type, is_numeric($name) ? null : $name);
             }
         } else {
             foreach ($this->types as $name => $type) {

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -77,14 +77,21 @@ class GraphQLTest extends TestCase
                 'updateExampleCustom' => UpdateExampleMutation::class
             ],
             'types' => [
-                CustomExampleType::class
+                CustomExampleType::class,
+                AnotherCustomExampleType::class
             ]
         ]);
-        
+
+        $graphql_types = GraphQL::getTypes();
+        $schema_types = $schema->getTypeMap();
+
         $this->assertGraphQLSchema($schema);
         $this->assertGraphQLSchemaHasQuery($schema, 'examplesCustom');
         $this->assertGraphQLSchemaHasMutation($schema, 'updateExampleCustom');
-        $this->assertArrayHasKey('CustomExample', $schema->getTypeMap());
+        $this->assertArrayHasKey('CustomExample', $schema_types);
+        $this->assertArrayHasKey('AnotherCustomExample', $schema_types);
+        $this->assertArrayHasKey('CustomExample', $graphql_types);
+        $this->assertArrayHasKey('AnotherCustomExample', $graphql_types);
     }
     
     /**

--- a/tests/Objects/AnotherCustomExampleType.php
+++ b/tests/Objects/AnotherCustomExampleType.php
@@ -1,0 +1,23 @@
+<?php
+
+use GraphQL\Type\Definition\Type;
+use Folklore\GraphQL\Support\Type as GraphQLType;
+
+class AnotherCustomExampleType extends GraphQLType
+{
+
+    protected $attributes = [
+        'name' => 'AnotherCustomExample',
+        'description' => 'An example'
+    ];
+
+    public function fields()
+    {
+        return [
+            'test' => [
+                'type' => Type::string(),
+                'description' => 'A test field'
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Fixes #365 
The schema actually gets the correct types, it's just the GraphQL facade that doesn't load them correctly. Which means GraphQL::type() doesn't work for types specified in the types array of a schema.

Although really only the second and later types fail because 0 coerces to false and is therefore ignored