### PR TITLE
Clarify usage of relay branch in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ This package is compatible with Eloquent model (or any other data source). See t
 [![Total Downloads](https://poser.pugx.org/folklore/graphql/downloads.svg)](https://packagist.org/packages/folklore/graphql)
 
 ----
-### To use laravel-graphql with Relay, check the [feature/relay](https://github.com/Folkloreatelier/laravel-graphql/tree/feature/relay) branch.
+### To use laravel-graphql with Relay Classic (Relay versions less than 1.0.0), check the [feature/relay](https://github.com/Folkloreatelier/laravel-graphql/tree/feature/relay) branch. Relay Modern (Relay versions 1.0.0 and up) works with the master branch of this repository.
 ----
 
 ## Installation


### PR DESCRIPTION
Relay Modern doesn't require the extra structures that are created in the relay branch.