### PR TITLE
Add setup method to field

### DIFF
--- a/src/Folklore/GraphQL/Support/Field.php
+++ b/src/Folklore/GraphQL/Support/Field.php
@@ -10,6 +10,15 @@ class Field extends Fluent
 
     /**
      * Override this in your queries or mutations
+     * to setup models for authorize, authenticated, resolve
+     */
+    public function setup($root, $args, $context)
+    {
+        return true;
+    }
+
+    /**
+     * Override this in your queries or mutations
      * to provide custom authorization
      */
     public function authorize($root, $args)
@@ -47,12 +56,16 @@ class Field extends Fluent
             return null;
         }
 
+        $setup = array($this, 'setup');
         $resolver = array($this, 'resolve');
         $authenticate = [$this, 'authenticated'];
         $authorize = [$this, 'authorize'];
 
-        return function () use ($resolver, $authorize, $authenticate) {
+        return function () use ($setup, $resolver, $authorize, $authenticate) {
             $args = func_get_args();
+
+            //Setup
+            call_user_func_array($setup, $args);
 
             // Authenticated
             if (call_user_func_array($authenticate, $args) !== true) {


### PR DESCRIPTION
Adding a setup method allows people to load models/resources once instead of multiple times. If you need to verify authorization via a field on a model you later need in resolve, you can load it in the setup method as a field on the mutation/query. 

I can provide an example if the usefulness of this is not clear. 