### PR TITLE
normalize $prefix to make it useable as schema

### DIFF
--- a/src/Folklore/GraphQL/GraphQLController.php
+++ b/src/Folklore/GraphQL/GraphQLController.php
@@ -19,7 +19,7 @@ class GraphQLController extends Controller
          * @see https://laravel.com/api/5.5/Illuminate/Http/Request.html#method_route
          */
         
-        $prefix = config('graphql.prefix');
+        $prefix = str_replace('/','_',config('graphql.prefix'));
         
         $routeName = is_object($route)
             ? $route->getName()


### PR DESCRIPTION
hi
this controller uses graphql.prefix config as part of shema name but prefix can be some thing like `api/graphql` or something like it
i just normalize it to make it to search for `api_graphql_schema` instead of `api/graphql_schema` which isn't a valid route param name
for this instance graphql.php is :

```php
[
    'prefix' => 'api/graphql',
    'routes' => '{api_graphql_schema?}',
]
```